### PR TITLE
Fixed some memory and include related compiler errors

### DIFF
--- a/src/algorithm/hash.cpp
+++ b/src/algorithm/hash.cpp
@@ -24,6 +24,8 @@
  * SOFTWARE.
  */
 
+#include <cstdint>
+
 #include "hash.h"
 
 namespace algorithm {

--- a/src/algorithm/hyper_log_log.h
+++ b/src/algorithm/hyper_log_log.h
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <algorithm>
 #include <iostream>
+#include <vector>
 
 namespace algorithm {
 

--- a/src/algorithm/intersection.cpp
+++ b/src/algorithm/intersection.cpp
@@ -24,6 +24,8 @@
  * SOFTWARE.
  */
 
+#include <functional>
+
 #include "intersection.h"
 
 namespace algorithm {

--- a/src/file/archive.cpp
+++ b/src/file/archive.cpp
@@ -116,7 +116,7 @@ namespace file {
 			std::string buffer_string(buffer, header.m_len);
 			std::stringstream buffer_stream(buffer_string);
 
-			delete buffer;
+			delete[] buffer;
 
 			boost::iostreams::filtering_istream decompress_stream;
 			decompress_stream.push(boost::iostreams::gzip_decompressor());
@@ -147,7 +147,7 @@ namespace file {
 			std::string buffer_string(buffer, header.m_len);
 			std::stringstream buffer_stream(buffer_string);
 
-			delete buffer;
+			delete[] buffer;
 
 			boost::iostreams::filtering_istream decompress_stream;
 			decompress_stream.push(boost::iostreams::gzip_decompressor());

--- a/src/indexer/score_builder.h
+++ b/src/indexer/score_builder.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <map>
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -59,7 +59,7 @@ namespace parser {
 
 		string ret_str(ret);
 
-		delete ret;
+		delete[] ret;
 
 		return ret_str;
 	}

--- a/src/tools/calculate_harmonic.cpp
+++ b/src/tools/calculate_harmonic.cpp
@@ -262,7 +262,7 @@ namespace tools {
 		}
 
 		ofstream outfile(config::data_path() + "/edges.txt", ios::trunc);
-		for (const pair<uint32_t, uint32_t> edge : edges) {
+		for (const pair<uint32_t, uint32_t>& edge : edges) {
 			outfile << edge.first << '\t' << edge.second << '\n';
 		}
 		outfile.close();

--- a/src/tools/counter.cpp
+++ b/src/tools/counter.cpp
@@ -99,7 +99,7 @@ namespace tools {
 			boost::iostreams::filtering_ostream compress_stream;
 			compress_stream.push(boost::iostreams::gzip_compressor());
 			compress_stream.push(outfile);
-			for (const string row : saved_rows) {
+			for (const string& row : saved_rows) {
 				compress_stream << row << "\n";
 			}
 		}

--- a/tests/test_index_reader.cpp
+++ b/tests/test_index_reader.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(test_index_reader1) {
 		BOOST_CHECK(res[1].m_value == 1001);
 		BOOST_CHECK(res[2].m_value == 1002);
 
-		delete buffer;
+		delete[] buffer;
 	}
 
 }

--- a/tests/test_memory.cpp
+++ b/tests/test_memory.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(test_memory) {
 	memory::update();
 
 	const size_t used2 = memory::allocated_memory();
-	delete some_mem;
+	delete[] some_mem;
 	const size_t used3 = memory::allocated_memory();
 
 	std::cout << "used1: " << used1 << std::endl;


### PR DESCRIPTION
Compiled under a different compiler deliberately to expose any errors that g++-10 doesn't warn about.

Note the memory allocation still doesn't align with coding rules but they are consistent with current code instead.